### PR TITLE
Add LiveScript module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "LiveScript": "^1.3.1",
     "prelude-ls": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
package.jsonにLiveScriptモジュールを追加しました。

◆追加原因
LiveScriptはv1.4からモジュール名が「livescript」となり、
v1.4以降を使用している場合はglad-functionsが使用できなくなっているため。