### PR TITLE
Remove prelude-ls from global object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,3 @@
 require("livescript")
-import$(global, require("prelude-ls"))
 module.exports = require("./lib/index.ls")
-
-function import$(obj, src){
-  for(var key in src) obj[key] = src[key];
-  return obj;
-}
-
 

--- a/lib/async.ls
+++ b/lib/async.ls
@@ -1,5 +1,6 @@
 {args, $_last_arg} = require \./func.ls
 {C} = require \./combinator.ls
+{apply} = require \prelude-ls
 
 module.exports = new class Async
   before: before = (f, g)-->

--- a/lib/combinator.ls
+++ b/lib/combinator.ls
@@ -1,4 +1,5 @@
 {return_} = require \./applicative.ls
+{flip, id, fix} = require \prelude-ls
 
 module.exports = new class Combinator
   B: B = (<<)

--- a/lib/func.ls
+++ b/lib/func.ls
@@ -1,6 +1,10 @@
 {when_} = require \./flow.ls
 {length} = require \./list.ls
 {C} = require \./combinator.ls
+{
+  at, map, split-at, id, take, map, tail, concat,
+  zip-with, apply, find-index, obj-to-pairs, pairs-to-obj
+} = require \prelude-ls
 
 module.exports = new class Func
   $: $ = (f, x)-->

--- a/lib/list.ls
+++ b/lib/list.ls
@@ -1,5 +1,6 @@
 {get} = require \./obj.ls
 {may} = require \./option.ls
+{find, filter, map, all, at, id} = require \prelude-ls
 
 module.exports = new class List
   find_map: find_map = (f, xs)-->

--- a/lib/obj.ls
+++ b/lib/obj.ls
@@ -1,3 +1,5 @@
+{map, obj-to-pairs, concat, pairs-to-obj} = require \prelude-ls
+
 module.exports = new class Obj
   let_: let_ = (x, k, ...a)->
     x.(k).apply x, a

--- a/lib/str.ls
+++ b/lib/str.ls
@@ -1,4 +1,5 @@
 {let_} = require \./obj.ls
+{flip} = require \prelude-ls
 
 module.exports = new class Str
   match_: match_ = flip (let_ _, \match, _)

--- a/test/assertions/func.ls
+++ b/test/assertions/func.ls
@@ -1,6 +1,7 @@
 {length} = require \../../lib/list.ls
 {act} = require \../../lib/flow.ls
 {deep-equal, equal, throws} = require \assert
+{map, apply, filter, head} = require \prelude-ls
 
 module.exports = new class FuncAssertion
   $: $ = ($)->

--- a/test/assertions/list.ls
+++ b/test/assertions/list.ls
@@ -2,6 +2,7 @@
 {match_} = require \../../lib/str.ls
 {args} = require \../../lib/func.ls
 {equal, deep-equal} = require \assert
+{at, join} = require \prelude-ls
 
 module.exports = new class FlowAssertion
   find_map: find_map =

--- a/test/assertions/option.ls
+++ b/test/assertions/option.ls
@@ -1,4 +1,5 @@
 {equal, does-not-throw, throws} = require \assert
+{find} = require \prelude-ls
 
 module.exports = new class OptionAssertion
   may: may =

--- a/test/assertions/str.ls
+++ b/test/assertions/str.ls
@@ -1,5 +1,6 @@
 {match_} = require \../../lib/str.ls
 {equal} = require \assert
+{at} = require \prelude-ls
 
 module.exports = new class FlowAssertion
   match_: match_ =

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,2 @@
 require("livescript")
-import$(global, require("prelude-ls"))
 require("./index.ls")
-
-function import$(obj, src){
-  for (var key in src) obj[key] = src[key];
-  return obj;
-}
-

--- a/test/index.ls
+++ b/test/index.ls
@@ -1,6 +1,7 @@
 {catch_} = require \../lib/control.ls
 {$} = require \../lib/func.ls
 require! <[fs colors]>
+{reject, each, obj-to-pairs, is-type, camelize, capitalize} = require \prelude-ls
 
 do main = ->
   err, files <- fs.readdir "#__dirname/../lib"


### PR DESCRIPTION
globalオブジェクトにprelude-lsをインポートしないように修正しました。

※修正理由
browserifyでコンパイルしてブラウザ側で使用する際に、
globalにprelude-lsが読み込まれてしまうことによって、
`id="global"`が含まれるDOM要素が`id="function(e){ return e;}"`に書き換わってしまうため。